### PR TITLE
fix: specify SameSite attribute explicitly

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -101,7 +101,7 @@ async function response(event) {
         statusText: 'No Content'
     });
 
-    if (!_uuid) response.headers.set('Set-Cookie', `uuid=${uuid}; Expires=${new Date((new Date().getTime() + 365 * 86400 * 30 * 1000)).toGMTString()}; Path='/';`);
+    if (!_uuid) response.headers.set('Set-Cookie', `uuid=${uuid}; Expires=${new Date((new Date().getTime() + 365 * 86400 * 30 * 1000)).toGMTString()}; Path='/'; SameSite=Lax;`);
 
     return response
 }


### PR DESCRIPTION
Specify `SameSite` attribute of the `Set-Cookie` explicitly to clearly communicate the intent which `SameSite` policy applies to the uuid cookie and prevent the 'Some cookies are misusing the "sameSite" attribute' message in console.

If you do not think this is necessary, simply close this pull request. 😀
